### PR TITLE
Update fr.po

### DIFF
--- a/ui/po/fr.po
+++ b/ui/po/fr.po
@@ -23,7 +23,7 @@ msgid ""
 "Switches your glasses into side-by-side mode and doubles the width of the "
 "display."
 msgstr ""
-"Basculez vos lunettes en mode côte à côte et doublez la largeur de l'écran."
+"Basculez vos lunettes en mode Side-By-Side (Côte-à-Côte) et doublez la largeur de l'écran."
 
 #: src/connecteddevice.py:17
 msgid "This feature is not currently supported for your device."
@@ -56,7 +56,7 @@ msgstr " ({time_remaining} restant)"
 
 #: src/licensefeaturerow.py:32
 msgid "Side-by-side mode (gaming)"
-msgstr "Mode côte à côte (jeu)"
+msgstr "Mode SBS (jeu)"
 
 #: src/licensefeaturerow.py:33
 msgid "Smooth Follow (gaming)"
@@ -64,7 +64,7 @@ msgstr "Suivi fluide (jeu)"
 
 #: src/licensefeaturerow.py:34
 msgid "Breezy Desktop (productivity)"
-msgstr "Bureau aéré (productivité)"
+msgstr "Breezy Desktop (productivité)"
 
 #: src/licensetierrow.py:24
 msgid "Active"
@@ -163,7 +163,7 @@ msgstr "Effet XR"
 
 #: src/gtk/connected-device.ui:45
 msgid "Enables the Breezy Desktop XR effect."
-msgstr "Active l'effet de bureau aéré XR."
+msgstr "Active l'effet Breezy Desktop XR."
 
 #: src/gtk/connected-device.ui:55
 msgid "Widescreen mode"
@@ -198,7 +198,7 @@ msgid ""
 "Closer appears larger, further appears smaller. Controls depth when in "
 "widescreen mode."
 msgstr ""
-"Plus proche apparaît plus grand, plus loin apparaît plus petit. Contrôle la "
+"Plus proche apparaît plus grand, plus éloigné apparaît plus petit. Contrôle la "
 "profondeur lorsque vous êtes en mode grand écran."
 
 #: src/gtk/connected-device.ui:123
@@ -231,7 +231,7 @@ msgstr "Seuil de suivi"
 
 #: src/gtk/connected-device.ui:179
 msgid "How far away you can look before the display follows."
-msgstr "Distance à laquelle vous pouvez regarder avant que l'affichage ne suive."
+msgstr "Distance jusqu'où vous pouvez regarder avant que l'affichage ne suive."
 
 #: src/gtk/connected-device.ui:209 src/gtk/connected-device.ui:215
 msgid "Keyboard Shortcuts"
@@ -280,7 +280,7 @@ msgid ""
 "resolution and best scaling when plugged in."
 msgstr ""
 "Modifiez automatiquement la configuration d'affichage des lunettes pour une "
-"résolution maximale et un meilleur масштаб lorsque elles sont branchées."
+"résolution maximale et une meilleure mise à l'échelle lorsque elles sont branchées."
 
 #: src/gtk/connected-device.ui:332
 msgid "Use highest refresh rate"
@@ -288,7 +288,7 @@ msgstr "Utiliser le taux de rafraîchissement le plus élevé"
 
 #: src/gtk/connected-device.ui:333
 msgid "Refresh rate may affect performance, disable this to set it manually."
-msgstr "Le taux de rafraîchissement peut affecter les performances, désactivez-le pour le définir manuellement."
+msgstr "Un taux de rafraîchissement élevé peut affecter les performances, désactivez-le pour le définir manuellement."
 
 #: src/gtk/connected-device.ui:343
 msgid "Always primary display"
@@ -307,7 +307,7 @@ msgid ""
 "Switches glasses to SBS mode immediately when plugged in, if widescreen mode "
 "is on. May cause instability."
 msgstr ""
-"Bascule les lunettes vers le mode SBS immédiatement lorsqu'elles sont branchées, "
+"Bascule les lunettes vers le mode SBS immédiatement lorsqu'elles sont branchées "
 "si le mode grand écran est activé. Peut provoquer des instabilités."
 
 #: src/gtk/connected-device.ui:365
@@ -322,7 +322,7 @@ msgid ""
 msgstr ""
 "Compense le lag d'entrée en prédisant la position de suivi de la tête avant "
 "le temps de rendu. Restez sur la valeur par défaut à moins que l'affichage virtuel "
-"ne soit lent, ne saute pas ou est très instable."
+"ne soit lent, ne saute pas ou ne soit très instable."
 
 #: src/gtk/connected-device.ui:384
 msgid "Default"
@@ -351,11 +351,11 @@ msgstr "Faire un don"
 
 #: src/gtk/license-dialog.ui:44
 msgid "Request a token"
-msgstr "Demander un jeton"
+msgstr "Demander un jeton d'authentification"
 
 #: src/gtk/license-dialog.ui:52
 msgid "Verify token"
-msgstr "Vérifier le jeton"
+msgstr "Vérifier le jeton d'authentification"
 
 #: src/gtk/no-device.ui:13
 msgid "No device connected"


### PR DESCRIPTION
A few modifications of the french translation to correct errors and make it more natural.

I finally opted to keep "SBS" and translated it once to "Côte à Côte" in parenthesis as I've found both "Side-by-Side" and "Côte-à-Côte" being used on french websites. This way we keep consistency with other settings about SBS.

The rest of the modifications is mostly personnal preference. 
I added "d'authentification" to Jeton (token) as I thought it could confuse non techy users. We often use the english word 'token' too in this context. Not sure wich is best, I leave it to you to decide.