### PR TITLE
Add monitor names for xbx-a01/xbx-a01+ glasses for GNOME and KWin

### DIFF
--- a/gnome/src/monitormanager.js
+++ b/gnome/src/monitormanager.js
@@ -38,6 +38,8 @@ export const SUPPORTED_MONITOR_PRODUCTS = [
     'XREAL One',
     'XREAL One Pro',
     'XREAL 1S',
+    'xbx a01',
+    'xbx a01+',
     'SmartGlasses', // TCL/RayNeo
     'Rokid Max',
     'Rokid Max 2',

--- a/kwin/src/qml/main.qml
+++ b/kwin/src/qml/main.qml
@@ -21,6 +21,8 @@ Item {
         "XREAL One",
         "XREAL One Pro",
         "XREAL 1S",
+        "xbx a01",
+        "xbx a01+",
         "SmartGlasses", // TCL/RayNeo
         "Rokid Max",
         "Rokid Max 2",


### PR DESCRIPTION
I have xbx-a01+ glasses, so xbx-a01 name is pure deduction (but I'm 99% sure it should work:))